### PR TITLE
articles slug validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /data
+*.DS_Store
 # Logs
 logs
 *.conf

--- a/app/routers/api/articleRouter.js
+++ b/app/routers/api/articleRouter.js
@@ -45,7 +45,7 @@ router.get('/admin', authorizeAccess(1), controllerHandler(articleController.get
  * @returns {Array<Article>} 200 - The article object
  * @returns {object} 500 - Internal server error
  */
-router.get('/:slug([a-z0-9-]+)', controllerHandler(articleController.getOne.bind(articleController)));
+router.get('/:slug([a-z0-9-’\']+)', controllerHandler(articleController.getOne.bind(articleController)));
 
 /**
  * GET /api/articles/admin/:slug
@@ -57,7 +57,7 @@ router.get('/:slug([a-z0-9-]+)', controllerHandler(articleController.getOne.bind
  * @returns {Array<Article>} 200 - The article object
  * @returns {object} 500 - Internal server error
  */
-router.get('/admin/:slug([a-z0-9-]+)', controllerHandler(articleController.getOnePrivate.bind(articleController)));
+router.get('/admin/:slug([a-z0-9-’\']+)', controllerHandler(articleController.getOnePrivate.bind(articleController)));
 
 /**
  * POST /api/articles
@@ -84,7 +84,7 @@ router.post('/', authorizeAccess(1), controllerHandler(articleController.uploadO
  * @returns {object} 403 - Forbidden
  * @returns {object} 500 - Internal server error
  */
-router.post('/:slug([a-z0-9-]+)/category/:id(\\d+)', authorizeAccess(1), controllerHandler(articleController.createCategoryRelation.bind(articleController)));
+router.post('/:slug([a-z0-9-’\']+)/category/:id(\\d+)', authorizeAccess(1), controllerHandler(articleController.createCategoryRelation.bind(articleController)));
 
 /**
  * PATCH /api/articles/:id
@@ -111,7 +111,7 @@ router.patch('/:id(\\d+)', authorizeAccess(1), controllerHandler(articleControll
  * @returns {object} 403 - Forbidden
  * @returns {object} 500 - Internal server error
  */
-router.delete('/:slug([a-z0-9-]+)', authorizeAccess(1), controllerHandler(articleController.deleteUploadedOne.bind(articleController)));
+router.delete('/:slug([a-z0-9-’\']+)', authorizeAccess(1), controllerHandler(articleController.deleteUploadedOne.bind(articleController)));
 
 /**
  * DELETE /api/articles/:slug/category/:id
@@ -125,6 +125,6 @@ router.delete('/:slug([a-z0-9-]+)', authorizeAccess(1), controllerHandler(articl
  * @returns {object} 403 - Forbidden
  * @returns {object} 500 - Internal server error
  */
-router.delete('/:slug([a-z0-9-]+)/category/:id(\\d+)', authorizeAccess(1), controllerHandler(articleController.deleteCategoryRelation.bind(articleController)));
+router.delete('/:slug([a-z0-9-’\']+)/category/:id(\\d+)', authorizeAccess(1), controllerHandler(articleController.deleteCategoryRelation.bind(articleController)));
 
 module.exports = router;

--- a/app/routers/api/articleRouter.js
+++ b/app/routers/api/articleRouter.js
@@ -45,7 +45,7 @@ router.get('/admin', authorizeAccess(1), controllerHandler(articleController.get
  * @returns {Array<Article>} 200 - The article object
  * @returns {object} 500 - Internal server error
  */
-router.get('/:slug([a-z0-9-’\']+)', controllerHandler(articleController.getOne.bind(articleController)));
+router.get('/:slug([a-z0-9-]+)', controllerHandler(articleController.getOne.bind(articleController)));
 
 /**
  * GET /api/articles/admin/:slug
@@ -57,7 +57,7 @@ router.get('/:slug([a-z0-9-’\']+)', controllerHandler(articleController.getOne
  * @returns {Array<Article>} 200 - The article object
  * @returns {object} 500 - Internal server error
  */
-router.get('/admin/:slug([a-z0-9-’\']+)', controllerHandler(articleController.getOnePrivate.bind(articleController)));
+router.get('/admin/:slug([a-z0-9-]+)', controllerHandler(articleController.getOnePrivate.bind(articleController)));
 
 /**
  * POST /api/articles
@@ -84,7 +84,7 @@ router.post('/', authorizeAccess(1), controllerHandler(articleController.uploadO
  * @returns {object} 403 - Forbidden
  * @returns {object} 500 - Internal server error
  */
-router.post('/:slug([a-z0-9-’\']+)/category/:id(\\d+)', authorizeAccess(1), controllerHandler(articleController.createCategoryRelation.bind(articleController)));
+router.post('/:slug([a-z0-9-]+)/category/:id(\\d+)', authorizeAccess(1), controllerHandler(articleController.createCategoryRelation.bind(articleController)));
 
 /**
  * PATCH /api/articles/:id
@@ -111,7 +111,7 @@ router.patch('/:id(\\d+)', authorizeAccess(1), controllerHandler(articleControll
  * @returns {object} 403 - Forbidden
  * @returns {object} 500 - Internal server error
  */
-router.delete('/:slug([a-z0-9-’\']+)', authorizeAccess(1), controllerHandler(articleController.deleteUploadedOne.bind(articleController)));
+router.delete('/:slug([a-z0-9-]+)', authorizeAccess(1), controllerHandler(articleController.deleteUploadedOne.bind(articleController)));
 
 /**
  * DELETE /api/articles/:slug/category/:id
@@ -125,6 +125,6 @@ router.delete('/:slug([a-z0-9-’\']+)', authorizeAccess(1), controllerHandler(a
  * @returns {object} 403 - Forbidden
  * @returns {object} 500 - Internal server error
  */
-router.delete('/:slug([a-z0-9-’\']+)/category/:id(\\d+)', authorizeAccess(1), controllerHandler(articleController.deleteCategoryRelation.bind(articleController)));
+router.delete('/:slug([a-z0-9-]+)/category/:id(\\d+)', authorizeAccess(1), controllerHandler(articleController.deleteCategoryRelation.bind(articleController)));
 
 module.exports = router;

--- a/app/validations/schemas/article-schema.js
+++ b/app/validations/schemas/article-schema.js
@@ -14,5 +14,4 @@ const modifyArticle = Joi.object({
   figcaption: Joi.string(),
 }).required().min(1);
 
-// .regex(/^[a-zA-Z0-9']+$/)
 module.exports = { createArticle, modifyArticle };

--- a/app/validations/schemas/article-schema.js
+++ b/app/validations/schemas/article-schema.js
@@ -1,14 +1,14 @@
 const Joi = require('joi');
 
 const createArticle = Joi.object({
-  title: Joi.string().regex(/^[a-zA-Z0-9' ]+$/).required(),
+  title: Joi.string().regex(/^[a-zA-Z0-9\s'-?!@&:/]+$/).required(),
   content: Joi.string().required(),
   publication_date: Joi.string().required(),
   figcaption: Joi.string().allow(null, ''),
 }).required();
 
 const modifyArticle = Joi.object({
-  title: Joi.string().regex(/^[a-zA-Z0-9' ]+$/),
+  title: Joi.string().regex(/^[a-zA-Z0-9\s'-?!@&:/]+$/),
   content: Joi.string(),
   publication_date: Joi.string(),
   figcaption: Joi.string(),

--- a/app/validations/schemas/article-schema.js
+++ b/app/validations/schemas/article-schema.js
@@ -1,17 +1,18 @@
 const Joi = require('joi');
 
 const createArticle = Joi.object({
-  title: Joi.string().required(),
+  title: Joi.string().regex(/^[a-zA-Z0-9' ]+$/).required(),
   content: Joi.string().required(),
   publication_date: Joi.string().required(),
   figcaption: Joi.string().allow(null, ''),
 }).required();
 
 const modifyArticle = Joi.object({
-  title: Joi.string(),
+  title: Joi.string().regex(/^[a-zA-Z0-9' ]+$/),
   content: Joi.string(),
   publication_date: Joi.string(),
   figcaption: Joi.string(),
 }).required().min(1);
 
+// .regex(/^[a-zA-Z0-9']+$/)
 module.exports = { createArticle, modifyArticle };

--- a/migrations/deploy/functions.sql
+++ b/migrations/deploy/functions.sql
@@ -91,17 +91,22 @@ CREATE OR REPLACE FUNCTION insert_article(json_data json)
   RETURNS "article" AS $$
   DECLARE
     new_article "article";
+    converted_title text;
   BEGIN
-    INSERT INTO "article"("slug", "title", "content", "author_id", "image", "figcaption", "publication_date")
+    converted_title := LOWER(json_data->>'title');
+    converted_title := regexp_replace(converted_title, ' ', '-', 'g');
+    converted_title := regexp_replace(converted_title, '[^[:alnum:]-]+', '', 'g');
+
+    INSERT INTO "article" ("slug", "title", "content", "author_id", "image", "figcaption", "publication_date")
     VALUES (
-      REPLACE(REPLACE(LOWER(json_data->>'title'), ' ', '-'), '''', '')::text,
+      converted_title,
       (json_data->>'title')::text,
       (json_data->>'content')::text,
       (json_data->>'author_id')::int,
       (json_data->>'image')::text,
       (json_data->>'figcaption')::text,
       (json_data->>'publication_date')::TIMESTAMPTZ
-	) RETURNING * INTO new_article;
+    ) RETURNING * INTO new_article;
 
     RETURN new_article;
   END;
@@ -111,9 +116,13 @@ CREATE OR REPLACE FUNCTION update_article(json_data json)
 RETURNS "article" AS $$
   DECLARE
     updated_article "article";
+    converted_title text;
   BEGIN
+    converted_title := LOWER(json_data->>'title')::text;
+    converted_title := regexp_replace(converted_title, ' ', '-', 'g');
+    converted_title := regexp_replace(converted_title, '[^[:alnum:]-]+', '', 'g');
     UPDATE "article" SET
-      "slug" = COALESCE(REPLACE(REPLACE(LOWER(json_data->>'title'), ' ', '-'), '''', ''), "slug"),
+      "slug" = COALESCE(converted_title, "slug"),
       "title" = COALESCE((json_data->>'title')::text, "title"),
       "content" = COALESCE((json_data->>'content')::text, "content"),
       "author_id" = COALESCE((json_data->>'author_id')::int, "author_id"),

--- a/migrations/deploy/functions.sql
+++ b/migrations/deploy/functions.sql
@@ -94,7 +94,7 @@ CREATE OR REPLACE FUNCTION insert_article(json_data json)
   BEGIN
     INSERT INTO "article"("slug", "title", "content", "author_id", "image", "figcaption", "publication_date")
     VALUES (
-      REPLACE(LOWER(json_data->>'title'), ' ', '-')::text,
+      REPLACE(REPLACE(LOWER(json_data->>'title'), ' ', '-'), '''', '')::text,
       (json_data->>'title')::text,
       (json_data->>'content')::text,
       (json_data->>'author_id')::int,
@@ -113,7 +113,7 @@ RETURNS "article" AS $$
     updated_article "article";
   BEGIN
     UPDATE "article" SET
-      "slug" = COALESCE(REPLACE(LOWER(json_data->>'title'), ' ', '-'), "slug"),
+      "slug" = COALESCE(REPLACE(REPLACE(LOWER(json_data->>'title'), ' ', '-'), '''', ''), "slug"),
       "title" = COALESCE((json_data->>'title')::text, "title"),
       "content" = COALESCE((json_data->>'content')::text, "content"),
       "author_id" = COALESCE((json_data->>'author_id')::int, "author_id"),


### PR DESCRIPTION
Since the backend is the one taking care of generating the slug, it needs to be coherent with the database.

In the rest api lvl, modified the validation schema to only accept title that have
- have letter from a to z (lower case/upper case)
- `'` single quote
- ` ` whitespace (space)
- numbers from 0 to 9

in the database lvl, modified the SQL function for insert and update article so that:
the slug is equal to title but it:
- removes all `'`
*note that a single quote can works in database but if I try to get the information from a url,  the single quote is ignored  by most http clients(chrome, axios, rest client..etc) and which leads to a 404*
- replaced all ` ` spaces by `-` minus sign
- lowercase alphabet letters

lastly to consume/access the information through a request.params (:slug)
there is a regex to check if the url is valid... allows the database to use less resource as it directly leads to the next middleware that is a 404.
